### PR TITLE
Add looping background music system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore music files
+assets/music/*.mp3

--- a/assets/music/README.md
+++ b/assets/music/README.md
@@ -1,0 +1,1 @@
+Place your music files in this folder. Name the default track 'main_theme.mp3'.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
     <!-- Cute pixelated snail that crawls around the screen -->
     <div id="snail">🐌</div>
 
+    <!-- Background music -->
+    <audio id="bg-music" src="assets/music/main_theme.mp3" loop hidden></audio>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,45 @@
 document.addEventListener('DOMContentLoaded', () => {
+    class MusicManager {
+        constructor() {
+            this.tracks = {};
+            this.current = null;
+        }
+
+        addTrack(name, src) {
+            const audio = new Audio(src);
+            audio.loop = true;
+            this.tracks[name] = audio;
+        }
+
+        play(name) {
+            const track = this.tracks[name];
+            if (!track) return;
+            if (this.current && this.current !== track) {
+                this.current.pause();
+                this.current.currentTime = 0;
+            }
+            this.current = track;
+            track.play().catch(() => {});
+        }
+
+        stop() {
+            if (this.current) {
+                this.current.pause();
+                this.current.currentTime = 0;
+                this.current = null;
+            }
+        }
+    }
+
+    const musicManager = new MusicManager();
+    musicManager.addTrack('main', 'assets/music/main_theme.mp3');
+
+    function enableMusic() {
+        musicManager.play('main');
+    }
+
+    // Autoplay restrictions require a user gesture
+    window.addEventListener('click', enableMusic, { once: true });
     const mainTaskInput = document.getElementById('main-task-input');
     const submitMainTask = document.getElementById('submit-main-task');
     const mainTaskDisplay = document.getElementById('main-task-display');


### PR DESCRIPTION
## Summary
- add a simple music manager to play tracks in a loop
- start music on first user click to satisfy autoplay rules
- embed a hidden `<audio>` element for the main theme
- ignore `.mp3` files and document where to place them

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687435caeed8832a9603fa80affbe15f