### PR TITLE
Improve asset loading with ship tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,15 @@
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
 </head>
 <body>
+    <div id="tab-nav">
+        <button class="tab-button active" data-tab="ship">Ship</button>
+        <button class="tab-button" data-tab="animations">Animations</button>
+    </div>
+
+    <div id="loading-overlay" class="hidden">
+        <div class="spinner"></div>
+    </div>
+
     <div class="container">
         <h1>My Priority Task</h1>
         <p id="summary" class="summary"></p>
@@ -41,6 +50,19 @@
         <h2>Take a Break: Flappy Bird</h2>
         <canvas id="flappy-canvas" width="320" height="480"></canvas>
         <button id="flappy-start">Start Game</button>
+    </div>
+
+    <div id="ship-page" class="tab-page">
+        <div class="ship-background">
+            <img id="ship-image" alt="Ship">
+        </div>
+        <div class="ship-controls">
+            <button id="set-sail">Set Sail</button>
+        </div>
+    </div>
+
+    <div id="animations-page" class="tab-page hidden">
+        <p>Animations go here.</p>
     </div>
 
     <!-- Celebration Modal -->

--- a/script.js
+++ b/script.js
@@ -13,6 +13,57 @@ document.addEventListener('DOMContentLoaded', () => {
     const celebrationButton = document.getElementById('celebration-button');
     const summary = document.getElementById('summary');
 
+    // Tab and loading elements
+    const tabButtons = document.querySelectorAll('.tab-button');
+    const shipPage = document.getElementById('ship-page');
+    const animationsPage = document.getElementById('animations-page');
+    const loadingOverlay = document.getElementById('loading-overlay');
+    const shipImage = document.getElementById('ship-image');
+    const shipBg = document.querySelector('.ship-background');
+
+    const shipLocations = [
+        {
+            background: 'https://via.placeholder.com/800x300?text=Space+Background',
+            ship: 'https://via.placeholder.com/200x150?text=Ship'
+        },
+        {
+            background: 'https://via.placeholder.com/800x300?text=Island+Background',
+            ship: 'https://via.placeholder.com/200x150?text=Pirate+Ship'
+        }
+    ];
+    let currentLocation = 0;
+    const loadedLocations = {};
+
+    function preloadAssets(assets) {
+        const urls = Object.values(assets);
+        return Promise.all(urls.map(url => new Promise(resolve => {
+            const img = new Image();
+            img.src = url;
+            img.onload = resolve;
+        })));
+    }
+
+    function initShipPage(index = currentLocation) {
+        const assets = shipLocations[index];
+        shipImage.src = assets.ship;
+        shipBg.style.backgroundImage = `url(${assets.background})`;
+        shipImage.classList.add('visible');
+        shipBg.classList.add('visible');
+    }
+
+    function showTab(tab) {
+        shipPage.classList.add('hidden');
+        animationsPage.classList.add('hidden');
+        if (tab === 'ship') {
+            shipPage.classList.remove('hidden');
+        } else {
+            animationsPage.classList.remove('hidden');
+        }
+        tabButtons.forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.tab === tab);
+        });
+    }
+
     function triggerLaserOverlay() {
         const overlay = document.createElement('div');
         overlay.className = 'laser-overlay';
@@ -258,6 +309,39 @@ document.addEventListener('DOMContentLoaded', () => {
             e.preventDefault();
             flap();
         }
+    });
+
+    // Preload ship assets on initial load
+    loadingOverlay.classList.remove('hidden');
+    preloadAssets(shipLocations[currentLocation]).then(() => {
+        loadedLocations[currentLocation] = true;
+        initShipPage(currentLocation);
+        loadingOverlay.classList.add('hidden');
+        showTab('ship');
+    });
+
+    document.getElementById('set-sail').addEventListener('click', () => {
+        const nextIndex = (currentLocation + 1) % shipLocations.length;
+        shipImage.classList.remove('visible');
+        shipBg.classList.remove('visible');
+        if (loadedLocations[nextIndex]) {
+            currentLocation = nextIndex;
+            initShipPage(nextIndex);
+        } else {
+            loadingOverlay.classList.remove('hidden');
+            preloadAssets(shipLocations[nextIndex]).then(() => {
+                loadedLocations[nextIndex] = true;
+                currentLocation = nextIndex;
+                initShipPage(nextIndex);
+                loadingOverlay.classList.add('hidden');
+            });
+        }
+    });
+
+    tabButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            showTab(btn.dataset.tab);
+        });
     });
 
     updateSummary();

--- a/styles.css
+++ b/styles.css
@@ -245,3 +245,100 @@ h2 {
     background-color: rgba(0,0,0,0.6);
     box-shadow: 0 0 5px #08f, 0 0 10px #08f;
 }
+
+/* Tab Navigation */
+#tab-nav {
+    display: flex;
+    justify-content: center;
+    margin: 1rem 0;
+    gap: 1rem;
+}
+
+.tab-button {
+    background: transparent;
+    color: #0ff;
+    border: 2px solid #08f;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.tab-button.active {
+    background-color: rgba(0,0,0,0.6);
+    box-shadow: 0 0 5px #08f;
+}
+
+.tab-page {
+    display: none;
+    margin: 2rem auto;
+    max-width: 600px;
+}
+
+.tab-page:not(.hidden) {
+    display: block;
+}
+
+.ship-background {
+    position: relative;
+    width: 100%;
+    height: 300px;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+#ship-image {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 200px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.ship-background.visible,
+#ship-image.visible {
+    opacity: 1;
+}
+
+.ship-controls {
+    text-align: center;
+    margin-top: 1rem;
+}
+
+#set-sail {
+    width: auto;
+}
+
+#loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 3000;
+}
+
+#loading-overlay.hidden {
+    display: none;
+}
+
+.spinner {
+    border: 4px solid #0ff;
+    border-top: 4px solid transparent;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- add set sail button and extra ship location
- preload ship assets and cache per-location
- hide ship elements until assets are loaded and fade them in

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874327d6a90832ab7f5e1aa19468a6c